### PR TITLE
修正Validator ipv4正则

### DIFF
--- a/src/Parameter/Validator.php
+++ b/src/Parameter/Validator.php
@@ -91,25 +91,25 @@ class Validator
 {
     public static $types = [
         'integer' => [
-            'regexp' => '/^\-?\d+$/',
+            'regexp'         => '/^\-?\d+$/',
             'allow_negative' => false,
-            'allow_zero' => true,
+            'allow_zero'     => true,
         ],
         'numeric' => [
-            'regexp' => '/^\-?\d+(?:\.\d+)?$/',
+            'regexp'         => '/^\-?\d+(?:\.\d+)?$/',
             'allow_negative' => false,
-            'allow_zero' => true,
+            'allow_zero'     => true,
         ],
-        'url' => [
+        'url'     => [
             'regexp' => '#^[a-z]+://[0-9a-z\-\.]+\.[0-9a-z]{1,4}(?:\d+)?(?:/[^\?]*)?(?:\?[^\#]*)?(?:\#[0-9a-z\-\_\/]*)?$#',
         ],
-        'uri' => [
+        'uri'     => [
             'regexp' => '#^/(?:[^?]*)?(?:\?[^\#]*)?(?:\#[0-9a-z\-\_\/]*)?$#',
         ],
-        'ipv4' => [
-            'regexp' => '/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/',
+        'ipv4'    => [
+            'regexp' => '/^(?:2(?:[0-4]\d|5[0-5])|1\d{2}|[1-9]?\d)(?:\.(?:2(?:[0-4]\d|5[0-5])|1\d{2}|[1-9]?\d)){3}$/',
         ],
-        'uuid' => [
+        'uuid'    => [
             'regexp' => '/^[0-9a-f]{8}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{12}$/i',
         ],
     ];
@@ -313,11 +313,11 @@ class Validator
         }
 
         $rule = array_merge([
-            'required' => true,
-            'allow_empty' => false,
-            'allow_tags' => false,
-            'regexp' => '',
-            'callback' => null,
+            'required'       => true,
+            'allow_empty'    => false,
+            'allow_tags'     => false,
+            'regexp'         => '',
+            'callback'       => null,
             '__normalized__' => true,
         ], $rule);
 
@@ -327,9 +327,9 @@ class Validator
     private function exception($key, $message)
     {
         $this->path[] = $key;
-        $message = 'Key ['.implode('=>', $this->path).'], '.$message;
+        $message      = 'Key ['.implode('=>', $this->path).'], '.$message;
 
-        $exception = new \Owl\Parameter\Exception($message);
+        $exception            = new \Owl\Parameter\Exception($message);
         $exception->parameter = $key;
 
         return $exception;

--- a/tests/Parameter/ValidatorTest.php
+++ b/tests/Parameter/ValidatorTest.php
@@ -1,8 +1,11 @@
 <?php
 namespace Tests\Parameter;
 
+use Owl\Parameter\Validator;
+
 class ValidatorTest extends \PHPUnit_Framework_TestCase
 {
+    /** @var Validator */
     private $validator;
 
     public function testRequired()
@@ -186,7 +189,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                             ],
                         ],
                         'd' => [
-                            'type' => 'array',
+                            'type'  => 'array',
                             'value' => [
                                 'type' => 'array',
                                 'keys' => [
@@ -227,7 +230,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 'a' => [
-                    'type' => 'array',
+                    'type'  => 'array',
                     'value' => [
                         'type' => 'array',
                         'keys' => [
@@ -258,7 +261,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 'a' => [
-                    'type' => 'array',
+                    'type'  => 'array',
                     'value' => ['type' => 'integer'],
                 ],
             ],
@@ -297,7 +300,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                             ],
                         ],
                         'd' => [
-                            'type' => 'array',
+                            'type'  => 'array',
                             'value' => [
                                 'type' => 'array',
                                 'keys' => [
@@ -338,7 +341,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 'a' => [
-                    'type' => 'json',
+                    'type'  => 'json',
                     'value' => [
                         'type' => 'array',
                         'keys' => [
@@ -360,7 +363,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 'a' => [
-                    'type' => 'object',
+                    'type'       => 'object',
                     'instanceof' => '\stdClass',
                 ],
             ]
@@ -372,7 +375,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 'a' => [
-                    'type' => 'object',
+                    'type'       => 'object',
                     'instanceof' => '\stdClass',
                 ],
             ],
@@ -415,6 +418,23 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         foreach ($test as $value) {
             $this->execute(['foo' => $value], $options);
         }
+    }
+
+    public function testIPV4()
+    {
+        $this->execute([
+            'valid_ip1' => '0.0.0.0',
+            'valid_ip2' => '255.199.99.9',
+            'valid_ip3' => '255.255.255.255',
+        ], [
+            'valid_ip1' => ['type' => 'ipv4'],
+            'valid_ip2' => ['type' => 'ipv4'],
+            'valid_ip3' => ['type' => 'ipv4'],
+        ]);
+
+        $this->tryExecute(['invalid_ip' => '0.0.0'], ['invalid_ip' => ['type' => 'ipv4']], 'test invalid IP1 failed');
+        $this->tryExecute(['invalid_ip' => '01.9.9.9'], ['invalid_ip' => ['type' => 'ipv4']], 'test invalid IP2 failed');
+        $this->tryExecute(['invalid_ip' => '256.255.255.255'], ['invalid_ip' => ['type' => 'ipv4']], 'test invalid IP3 failed');
     }
 
     public function testAllowTags()


### PR DESCRIPTION
验证ipv4的正则不够完整,对类似999.099.300.0这样的IP验证通过.
修改了正则,编写了测试代码.
